### PR TITLE
fix: Move Headers build phase above Sources to fix Xcode 13.3 bug

### DIFF
--- a/PusherSwift/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift/PusherSwift.xcodeproj/project.pbxproj
@@ -222,8 +222,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33831C9D1A9CF61600B124F1 /* Build configuration list for PBXNativeTarget "PusherSwift" */;
 			buildPhases = (
-				33831C841A9CF61600B124F1 /* Sources */,
 				33831C861A9CF61600B124F1 /* Headers */,
+				33831C841A9CF61600B124F1 /* Sources */,
 				33831C871A9CF61600B124F1 /* Resources */,
 				3358FA6E1B4FD8C000AB0670 /* ShellScript */,
 				50355EA8A07B4B8038A4DDF1 /* Frameworks */,
@@ -280,6 +280,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 33831C491A9CEDF800B124F1;


### PR DESCRIPTION
### Fix Xcode 13.3 bug
Without this adjustment, Xcode 13.3 would throw a build error with: `Cycle in dependencies between targets 'Music Stand' and 'PusherSwift'; building could produce unreliable results. This usually can be resolved by moving the target's Headers build phase before Compile Sources.`

### Why
I don't know why.... My system auto updated to Xcode 13.3 and I couldn't build anymore.  After some googling I found this post:  https://developer.apple.com/forums/thread/702349 that suggested I make the adjustment found in this PR

### How
In the Build Phases tab, click and draw the Headers phase above Compile Sources

### Things to note
I like potatoes

### Screenshot
N/A

