### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @planningcenter/mobile-engineering


### PR DESCRIPTION
Adding mobile engineering as codeowners. I'm also wanting to move the default branch to `main`. Is that an issue for the mobile apps?